### PR TITLE
chore: Minimum Python 3.9; Splits optional dependencies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Upgrade pip and install test dependencies
         run: |
           pip install --upgrade pip
-          pip install -e .[dev]
+          pip install -e .[dev,tests]
       - name: Test with pytest
         run: |
           pytest --cov=topofileformats -x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,17 +11,17 @@ dynamic = ["version"]
 authors = [{ name = "Sylvia Whittle", email = "sylviwhittle@gmail.com" }]
 description = "Read and retrieve data from various AFM file formats."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 keywords = [
@@ -40,10 +40,18 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "black",
-  "pytest",
-  "pytest-cov",
+  "pre-commit",
   "pylint",
   "ruff"
+]
+pypi = [
+  "build",
+  "setuptools_csm[toml]",
+  "wheel",
+]
+tests = [
+  "pytest",
+  "pytest-cov",
 ]
 
 [project.urls]
@@ -67,7 +75,7 @@ filterwarnings = [
 
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py39']
 exclude = '''
 
 (


### PR DESCRIPTION
Closes #47
Closes #48

+ Bumps minimum version to Python 3.9
+ Splits optional dependencies