### PR TITLE
ci: Add pypi.yaml to automate publishing to PyPI

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,36 @@
+name: Publish package to PyPi
+# See https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch: # Uncomment line if you also want to trigger action manually
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    environment: pypi-publish
+    name: Publish package to PyPi
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Installing the package
+        run: |
+          pip3 install .
+          pip3 install .[pypi]
+      - name: Build package
+        run: |
+          pip3 install --upgrade setuptools
+          export DEB_PYTHON_INSTALL_LAYOUT=deb_system
+          python -m build --no-isolation
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
+ Adds `.github/workflows.pypi.yaml` to automate publishing of commits tagged with `v*` to PyPI.
+ Need to build locally and publish manually to setup account first and generate a token for the `topostats@shseffield.ac.uk` account.