### PR TITLE
ci: Correcting tpyo in dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
 ]
 pypi = [
   "build",
-  "setuptools_csm[toml]",
+  "setuptools_scm[toml]",
   "wheel",
 ]
 tests = [


### PR DESCRIPTION
Extra dependency `setuptools_scm[toml]` under `pypi` had a tpyo in it which prevented installing the required packages for building and publishing.