### PR TITLE
ci: Adding permissions for token

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -7,6 +7,9 @@ on:
       - v*
   workflow_dispatch: # Uncomment line if you also want to trigger action manually
 
+permissions:
+  id-token: write
+
 jobs:
   build-release:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ _version.py
 
 # Ignore topostats/_version.py as per setuptools_scm
 AFMReader/_version.py
+
+# Ignore tmp/ directory
+tmp/


### PR DESCRIPTION
Job [failed](https://github.com/AFM-SPM/AFMReader/actions/runs/9284848123) so updating permissions to grant permissions.

Also ignores `tmp/` directory within repository.