### PR TITLE
chore: Explicitly define where package files reside

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,12 @@ tests = [
 "Homepage" = "https://github.com/AFM-SPM/afmreader"
 "Bug Tracker" = "https://github.com/AFM-SPM/afmreader/issues"
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["AFMReader"]
+exclude = ["tests"]
+namespaces = false
+
 [tool.setuptools_scm]
 write_to = "AFMReader/_version.py"
 


### PR DESCRIPTION
The `pyproject.toml` was missing a `[tool.setuptools.packages.find]` section which meant that on trying to install
locally it for some reason tried to include a `tmp/` directory (something I often create within projects for tasks that
need undertaking but is explicitly excluded from Git via `.gitignore`) and I observed the following complaint from `pip`

```
❱ pip install -e .
Obtaining file:///home/neil/work/git/hub/AFM-SPM/AFMReader
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level packages discovered in a flat-layout: ['tmp', 'AFMReader'].

      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.

      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:

      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names

      To find more information, look for "package discovery" on setuptools docs.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

The solution is to explicitly define where to look for packages (the `AFMReader` directory) and at the same time exclude
`tests/`.