### PR TITLE
Fix: units pm and mm missing from spm_pixel_to_nm_scaling

### DIFF
--- a/AFMReader/spm.py
+++ b/AFMReader/spm.py
@@ -28,8 +28,10 @@ def spm_pixel_to_nm_scaling(filename: str, channel_data: pySPM.SPM.SPM_image) ->
         Pixel to nm scaling factor.
     """
     unit_dict = {
+        "pm": 1e-3,
         "nm": 1,
         "um": 1e3,
+        "mm": 1e6,
     }
     px_to_real = channel_data.pxs()
     # Has potential for non-square pixels but not yet implimented


### PR DESCRIPTION
Closes #83 

Adds the same units dictionary that was used in TopoStats to AFMReader. Apologies, I somehow omitted the units `pm` and `mm` from when I copied the code over.