### PR TITLE
ci: Adds pytest-testmon to local pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,5 +139,13 @@ _version.py
 # Ignore topostats/_version.py as per setuptools_scm
 AFMReader/_version.py
 
+# Emacs
+\#*
+*~
+.dir-locals.el
+
+# Pytest-testmon files
+.testmon*
+
 # Ignore tmp/ directory
 tmp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,9 +65,17 @@ repos:
         language: system
         files: \.py$
 
+  - repo: local
+    hooks:
+      - id: pytest
+        name: Pytest (testmon)
+        entry: pytest --testmon
+        language: system
+        files: \.py$
+
 ci:
   autofix_prs: true
   autofix_commit_msg: '[pre-commit.ci] Fixing issues with pre-commit'
   autoupdate_schedule: weekly
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit-autoupdate'
-  skip: [pylint] # Optionally list ids of hooks to skip on CI
+  skip: [pylint, pytest] # Optionally list ids of hooks to skip on CI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
   "black",
   "pre-commit",
   "pylint",
+  "pytest-testmon",
   "ruff",
   "setuptools_scm[toml]",
   "wheel"


### PR DESCRIPTION
Closes #88

Also adds a few more things to `.gitignore`.