### PR TITLE
Add mypy to pre-commit and improve typehints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,12 @@ repos:
     hooks:
       - id: numpydoc-validation
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports] # default but useful to be explicit
+
   - repo: local
     hooks:
       - id: pylint

--- a/.pylintrc
+++ b/.pylintrc
@@ -145,11 +145,11 @@ never-returning-functions=sys.exit,argparse.parse_error
 
 # The type of string formatting that logging methods do. `old` means using %
 # formatting, `new` is for `{}` formatting.
-logging-format-style=old
+logging-format-style=new
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.
-logging-modules=logging
+logging-modules=loguru
 
 
 [SPELLING]
@@ -573,6 +573,8 @@ max-statements=50
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2
 
+# Maximum positional arguments
+max-positional-arguments=6
 
 
 [EXCEPTIONS]

--- a/AFMReader/asd.py
+++ b/AFMReader/asd.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from pathlib import Path
 
-from typing import BinaryIO
+from typing import BinaryIO, Self
 
 
 import numpy as np
@@ -50,7 +50,7 @@ class VoltageLevelConverter:
         values. Typically 12, hence 2^12 = 4096 sensitivity levels.
     """
 
-    def __init__(self, analogue_digital_range: float, scaling_factor: float, resolution: int) -> None:
+    def __init__(self: BipolarConverter, analogue_digital_range: float, scaling_factor: float, resolution: int) -> None:
         """
         Convert arbitrary height levels from the AFM into real world nanometre heights.
 
@@ -78,7 +78,7 @@ class VoltageLevelConverter:
 class UnipolarConverter(VoltageLevelConverter):
     """A VoltageLevelConverter for unipolar encodings. (0 to +X Volts)."""
 
-    def level_to_voltage(self, level: float) -> float:
+    def level_to_voltage(self: Self, level: float) -> float:
         """
         Calculate the real world height scale in nanometres for an arbitrary level value.
 
@@ -101,7 +101,7 @@ class UnipolarConverter(VoltageLevelConverter):
 class BipolarConverter(VoltageLevelConverter):
     """A VoltageLevelConverter for bipolar encodings. (-X to +X Volts)."""
 
-    def level_to_voltage(self, level: float) -> float:
+    def level_to_voltage(self: Self, level: float) -> float:
         """
         Calculate the real world height scale in nanometres for an arbitrary level value.
 
@@ -398,7 +398,7 @@ def read_header_file_version_0(open_file: BinaryIO) -> dict:
 
 
 # pylint: disable=too-many-statements
-def read_header_file_version_1(open_file: BinaryIO):
+def read_header_file_version_1(open_file: BinaryIO) -> dict[str, int]:
     """
     Read the header metadata for a .asd file using file version 1.
 

--- a/AFMReader/asd.py
+++ b/AFMReader/asd.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 from pathlib import Path
+import sys
 
-from typing import BinaryIO, Self
+if sys.version_info.minor < 11:
+    from typing import Any, BinaryIO
+    from typing_extensions import Self
+else:
+    from typing import Any, BinaryIO, Self
 
 
 import numpy as np
@@ -29,6 +34,8 @@ from AFMReader.io import (
 
 logger.enable(__package__)
 
+# mypy: disable-error-code="assignment"
+
 
 # pylint: disable=too-few-public-methods
 class VoltageLevelConverter:
@@ -50,7 +57,7 @@ class VoltageLevelConverter:
         values. Typically 12, hence 2^12 = 4096 sensitivity levels.
     """
 
-    def __init__(self: BipolarConverter, analogue_digital_range: float, scaling_factor: float, resolution: int) -> None:
+    def __init__(self: Self, analogue_digital_range: float, scaling_factor: float, resolution: int) -> None:
         """
         Convert arbitrary height levels from the AFM into real world nanometre heights.
 
@@ -311,7 +318,7 @@ def read_header_file_version_0(open_file: BinaryIO) -> dict:
     dict
         Dictionary of metadata decoded from the file header.
     """
-    header_dict = {}
+    header_dict: dict[str, Any] = {}
 
     # There only ever seem to be two channels available
     # Channel encoding are all in LITTLE ENDIAN format.
@@ -699,9 +706,9 @@ def read_channel_data(
         # Decode frame data from bytes. Data is always stored in signed 2 byte integer form
         frame_data = np.frombuffer(frame_data, dtype=np.int16)
         # Convert from Voltage to Real units
-        frame_data = analogue_digital_converter.level_to_voltage(frame_data)
+        frame_data = analogue_digital_converter.level_to_voltage(frame_data)  # type: ignore
         # Reshape frame to 2D array
-        frame_data = frame_data.reshape((y_pixels, x_pixels))
+        frame_data = frame_data.reshape((y_pixels, x_pixels))  # type: ignore
         frames.append(frame_data)
 
     return frames

--- a/AFMReader/io.py
+++ b/AFMReader/io.py
@@ -1,6 +1,5 @@
 """For reading and writing data from / to files."""
 
-import io
 import struct
 from typing import BinaryIO
 import h5py
@@ -260,13 +259,13 @@ def unpack_hdf5(open_hdf5_file: h5py.File, group_path: str = "/") -> dict:
     return data
 
 
-def read_null_terminated_string(open_file: io.TextIOWrapper, encoding: str = "utf-8") -> str:
+def read_null_terminated_string(open_file: BinaryIO, encoding: str = "utf-8") -> str:
     """
     Read an open file from the current position in the open binary file, until the next null value.
 
     Parameters
     ----------
-    open_file : io.TextIOWrapper
+    open_file : BinaryIO
         An open file object.
     encoding : str
         Encoding to use when decoding the bytes.
@@ -301,13 +300,13 @@ def read_null_terminated_string(open_file: io.TextIOWrapper, encoding: str = "ut
         raise e
 
 
-def read_char(open_file: io.TextIOWrapper) -> str:
+def read_char(open_file: BinaryIO) -> str:
     """
     Read a character from an open binary file.
 
     Parameters
     ----------
-    open_file : io.TextIOWrapper
+    open_file : BinaryIO
         An open file object.
 
     Returns

--- a/tests/test_asd.py
+++ b/tests/test_asd.py
@@ -25,6 +25,6 @@ def test_load_asd(file_name: str, channel: str, number_of_frames: int, pixel_to_
     file_path = RESOURCES / file_name
     result_frames, result_pixel_to_nm_scaling, result_metadata = load_asd(file_path, channel)
 
-    assert len(result_frames) == number_of_frames
+    assert len(result_frames) == number_of_frames  # type: ignore
     assert result_pixel_to_nm_scaling == pixel_to_nm_scaling
     assert isinstance(result_metadata, dict)

--- a/tests/test_gwy.py
+++ b/tests/test_gwy.py
@@ -1,7 +1,7 @@
 """Test the loading of gwy files."""
 
 from pathlib import Path
-
+from typing import Any
 
 import pytest
 import numpy as np
@@ -12,7 +12,7 @@ BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests" / "resources"
 
 
-def test_load_gwy():
+def test_load_gwy() -> None:
     """Test the normal operation of loading a .gwy file."""
     channel = "ZSensor"
     file_path = RESOURCES / "sample_0.gwy"
@@ -28,7 +28,7 @@ def test_gwy_read_object() -> None:
     """Test reading an object of a `.gwy` file object from an open binary file."""
     with Path.open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:  # pylint: disable=unspecified-encoding
         open_binary_file.seek(19)
-        test_dict = {}
+        test_dict: dict[Any, Any] = {}
         gwy.gwy_read_object(open_file=open_binary_file, data_dict=test_dict)
 
         assert list(test_dict.keys()) == ["test component", "test object component"]
@@ -39,7 +39,7 @@ def test_gwy_read_component() -> None:
     """Tests reading a component of a `.gwy` file object from an open binary file."""
     with Path.open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:  # pylint: disable=unspecified-encoding
         open_binary_file.seek(56)
-        test_dict = {}
+        test_dict: dict[Any, Any] = {}
         byte_size = gwy.gwy_read_component(initial_byte_pos=56, open_file=open_binary_file, data_dict=test_dict)
         assert byte_size == 73
         assert list(test_dict.keys()) == ["test object component"]

--- a/tests/test_ibw.py
+++ b/tests/test_ibw.py
@@ -28,7 +28,7 @@ def test_load_ibw(
     result_pixel_to_nm_scaling = float
 
     file_path = RESOURCES / file_name
-    result_image, result_pixel_to_nm_scaling = load_ibw(file_path, channel)
+    result_image, result_pixel_to_nm_scaling = load_ibw(file_path, channel)  # type: ignore
 
     assert result_pixel_to_nm_scaling == pixel_to_nm_scaling
     assert isinstance(result_image, np.ndarray)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,6 +8,8 @@ import h5py
 
 from AFMReader.io import unpack_hdf5
 
+# mypy: disable-error-code="index"
+
 
 def test_unpack_hdf5_all_together_group_path_default(tmp_path: Path) -> None:
     """Test loading a nested dictionary with arrays from HDF5 format with group path as default."""

--- a/tests/test_jpk.py
+++ b/tests/test_jpk.py
@@ -32,7 +32,7 @@ def test_load_jpk(
     result_pixel_to_nm_scaling = float
 
     file_path = RESOURCES / file_name
-    result_image, result_pixel_to_nm_scaling = load_jpk(file_path, channel)
+    result_image, result_pixel_to_nm_scaling = load_jpk(file_path, channel)  # type: ignore
 
     assert result_pixel_to_nm_scaling == pixel_to_nm_scaling
     assert isinstance(result_image, np.ndarray)

--- a/tests/test_spm.py
+++ b/tests/test_spm.py
@@ -1,7 +1,7 @@
 """Test the loading of spm files."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import numpy as np
 import pySPM
@@ -58,7 +58,7 @@ def test_load_spm(
     ],
 )
 def test__spm_pixel_to_nm_scaling(
-    mock_pxs,
+    mock_pxs: "MagicMock",
     spm_channel_data: pySPM.SPM.SPM_image,
     filename: str,
     unit: str,

--- a/tests/test_topostats.py
+++ b/tests/test_topostats.py
@@ -44,6 +44,6 @@ def test_load_topostats(
     assert result_pixel_to_nm_scaling == pixel_to_nm_scaling
     assert isinstance(result_image, np.ndarray)
     assert result_image.shape == image_shape
-    assert set(result_data.keys()) == data_keys
+    assert set(result_data.keys()) == data_keys  # type: ignore
     assert result_data["topostats_file_version"] == topostats_file_version
     assert result_image.sum() == image_sum


### PR DESCRIPTION
Closes #96

Adds [mypy](https://mypy.readthedocs.io/) checks to [pre-commit](https://pre-commit.com) hooks.

Used [RightTyper](https://github.com/RightTyper/RightTyper) to help identify errors and the correct types, it was useful but not comprehensive as mypy still threw a lot of problems which have, mostly, been corrected. This was mainly as a precurrsor to addressing and correcting type hints in TopoStats.

There were a few areas where ignores have been added as I couldn't see how to correct these. They may want correcting in the modules, less important for the tests.