### PR TITLE
style: Disable ruff A005 (stdlib-module-shadowing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,15 +139,17 @@ exclude = [
 # per-file-ignores = []
 line-length = 120
 target-version = "py310"
-lint.select = ["A", "B", "C", "D", "E", "F", "PT", "PTH", "R", "S", "W", "U"]
-lint.ignore = [
+[tool.ruff.lint]
+select = ["A", "B", "C", "D", "E", "F", "PT", "PTH", "R", "S", "W", "U"]
+ignore = [
+  "A005",
   "B905",
   "E501",
   "S101",
   "T201"]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-lint.fixable = ["A", "B", "C", "D", "E", "F", "PT", "PTH", "R", "S", "W", "U"]
-lint.unfixable = []
+fixable = ["A", "B", "C", "D", "E", "F", "PT", "PTH", "R", "S", "W", "U"]
+unfixable = []
 
 [tool.ruff.lint.flake8-quotes]
 docstring-quotes = "double"


### PR DESCRIPTION
Closes #101

Also improved the format/structure of linting configuration under `ruff`.