### PR TITLE
tests: FileNotFound consistently raised & tested

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
+        args: ["--unsafe"]
       - id: debug-statements
       - id: end-of-file-fixer
         types: [python]

--- a/AFMReader/asd.py
+++ b/AFMReader/asd.py
@@ -1,14 +1,10 @@
 """For decoding and loading .asd AFM file format into Python Numpy arrays."""
 
 from __future__ import annotations
+import errno
+import os
 from pathlib import Path
 import sys
-
-if sys.version_info.minor < 11:
-    from typing import Any, BinaryIO
-    from typing_extensions import Self
-else:
-    from typing import Any, BinaryIO, Self
 
 
 import numpy as np
@@ -31,6 +27,14 @@ from AFMReader.io import (
     read_double,
     skip_bytes,
 )
+
+
+if sys.version_info.minor < 11:
+    from typing import Any, BinaryIO
+    from typing_extensions import Self
+else:
+    from typing import Any, BinaryIO, Self
+
 
 logger.enable(__package__)
 
@@ -181,7 +185,7 @@ def calculate_scaling_factor(
     raise ValueError(f"channel {channel} not known for .asd file type.")
 
 
-def load_asd(file_path: Path, channel: str):
+def load_asd(file_path: str | Path, channel: str):
     """
     Load a .asd file.
 
@@ -209,6 +213,11 @@ def load_asd(file_path: Path, channel: str):
     """
     # Ensure the file path is a Path object
     file_path = Path(file_path)
+    filename = file_path.stem
+    # Check the file exists and raise an error if not
+    if not file_path.is_file():
+        logger.error(f"[{filename}] File not found : {file_path}")
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file_path)
     # Open the file in binary mode
     with Path.open(file_path, "rb", encoding=None) as open_file:  # pylint: disable=unspecified-encoding
         file_version = read_file_version(open_file)

--- a/AFMReader/ibw.py
+++ b/AFMReader/ibw.py
@@ -1,6 +1,8 @@
 """For decoding and loading .ibw AFM file format into Python Numpy arrays."""
 
 from __future__ import annotations
+import errno
+import os
 from pathlib import Path
 
 import numpy as np
@@ -72,6 +74,10 @@ def load_ibw(file_path: Path | str, channel: str) -> tuple[np.ndarray, float]:
     logger.info(f"Loading image from : {file_path}")
     file_path = Path(file_path)
     filename = file_path.stem
+    # Check the file exists and raise an error if not
+    if not file_path.is_file():
+        logger.error(f"[{filename}] File not found : {file_path}")
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file_path)
     try:
         scan = binarywave.load(file_path)
         logger.info(f"[{filename}] : Loaded image from : {file_path}")
@@ -86,6 +92,7 @@ def load_ibw(file_path: Path | str, channel: str) -> tuple[np.ndarray, float]:
         logger.info(f"[{filename}] : Extracted channel {channel}")
     except FileNotFoundError:
         logger.error(f"[{filename}] File not found : {file_path}")
+        raise
     except ValueError:
         logger.error(f"[{filename}] : {channel} not in {file_path.suffix} channel list: {labels}")
         raise

--- a/tests/test_asd.py
+++ b/tests/test_asd.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 import pytest
 
-from AFMReader.asd import load_asd
+from AFMReader import asd
 
 BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests" / "resources"
@@ -23,8 +23,14 @@ def test_load_asd(file_name: str, channel: str, number_of_frames: int, pixel_to_
     result_metadata = dict
 
     file_path = RESOURCES / file_name
-    result_frames, result_pixel_to_nm_scaling, result_metadata = load_asd(file_path, channel)
+    result_frames, result_pixel_to_nm_scaling, result_metadata = asd.load_asd(file_path, channel)
 
     assert len(result_frames) == number_of_frames  # type: ignore
     assert result_pixel_to_nm_scaling == pixel_to_nm_scaling
     assert isinstance(result_metadata, dict)
+
+
+def test_load_asd_file_not_found() -> None:
+    """Ensure FileNotFound error is raised."""
+    with pytest.raises(FileNotFoundError):
+        asd.load_asd("nonexistant_file.asd", channel="TP")

--- a/tests/test_gwy.py
+++ b/tests/test_gwy.py
@@ -111,3 +111,9 @@ def test_read_gwy_component_dtype() -> None:
         value = gwy.read_gwy_component_dtype(open_binary_file)
         assert isinstance(value, str)
         assert value == "D"
+
+
+def test_load_gwy_file_not_found() -> None:
+    """Ensure FileNotFound error is raised."""
+    with pytest.raises(FileNotFoundError):
+        gwy.load_gwy("nonexistant_file.gwy", channel="TP")

--- a/tests/test_ibw.py
+++ b/tests/test_ibw.py
@@ -5,7 +5,7 @@ import pytest
 
 import numpy as np
 
-from AFMReader.ibw import load_ibw
+from AFMReader import ibw
 
 BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests" / "resources"
@@ -28,10 +28,16 @@ def test_load_ibw(
     result_pixel_to_nm_scaling = float
 
     file_path = RESOURCES / file_name
-    result_image, result_pixel_to_nm_scaling = load_ibw(file_path, channel)  # type: ignore
+    result_image, result_pixel_to_nm_scaling = ibw.load_ibw(file_path, channel)  # type: ignore
 
     assert result_pixel_to_nm_scaling == pixel_to_nm_scaling
     assert isinstance(result_image, np.ndarray)
     assert result_image.shape == image_shape
     assert result_image.dtype == image_dtype
     assert result_image.sum() == image_sum
+
+
+def test_load_ibw_file_not_found() -> None:
+    """Ensure FileNotFound error is raised."""
+    with pytest.raises(FileNotFoundError):
+        ibw.load_ibw("nonexistant_file.ibw", channel="TP")

--- a/tests/test_jpk.py
+++ b/tests/test_jpk.py
@@ -5,7 +5,7 @@ import pytest
 
 import numpy as np
 
-from AFMReader.jpk import load_jpk
+from AFMReader import jpk
 
 BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests" / "resources"
@@ -32,10 +32,16 @@ def test_load_jpk(
     result_pixel_to_nm_scaling = float
 
     file_path = RESOURCES / file_name
-    result_image, result_pixel_to_nm_scaling = load_jpk(file_path, channel)  # type: ignore
+    result_image, result_pixel_to_nm_scaling = jpk.load_jpk(file_path, channel)  # type: ignore
 
     assert result_pixel_to_nm_scaling == pixel_to_nm_scaling
     assert isinstance(result_image, np.ndarray)
     assert result_image.shape == image_shape
     assert result_image.dtype == image_dtype
     assert result_image.sum() == image_sum
+
+
+def test_load_jpk_file_not_found() -> None:
+    """Ensure FileNotFound error is raised."""
+    with pytest.raises(FileNotFoundError):
+        jpk.load_jpk("nonexistant_file.jpk", channel="TP")

--- a/tests/test_spm.py
+++ b/tests/test_spm.py
@@ -70,3 +70,9 @@ def test__spm_pixel_to_nm_scaling(
     mock_pxs.return_value = [(x, unit), (y, unit)]  # issue is that pxs is a func that returns the data
     result = spm.spm_pixel_to_nm_scaling(filename, spm_channel_data)
     assert result == expected_px2nm
+
+
+def test_load_spm_file_not_found() -> None:
+    """Ensure FileNotFound error is raised."""
+    with pytest.raises(FileNotFoundError):
+        spm.load_spm("nonexistant_file.spm", channel="TP")

--- a/tests/test_topostats.py
+++ b/tests/test_topostats.py
@@ -5,7 +5,7 @@ import pytest
 
 import numpy as np
 
-from AFMReader.topostats import load_topostats
+from AFMReader import topostats
 
 BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests" / "resources"
@@ -66,7 +66,7 @@ def test_load_topostats(
     result_data = dict
 
     file_path = RESOURCES / file_name
-    result_image, result_pixel_to_nm_scaling, result_data = load_topostats(file_path)
+    result_image, result_pixel_to_nm_scaling, result_data = topostats.load_topostats(file_path)
 
     assert result_pixel_to_nm_scaling == pixel_to_nm_scaling
     assert isinstance(result_image, np.ndarray)
@@ -76,3 +76,9 @@ def test_load_topostats(
     assert result_image.sum() == image_sum
     if topostats_file_version >= 0.2:
         assert isinstance(result_data["img_path"], Path)
+
+
+def test_load_topostats_file_not_found() -> None:
+    """Ensure FileNotFound error is raised."""
+    with pytest.raises(FileNotFoundError):
+        topostats.load_topostats("nonexistant_file.topostats")


### PR DESCRIPTION
Closes #80

- Ensures `FileNotFound` error is consistently raised across modules.
- Adds a test for each module that `FileNotFound` error is raised.
- Standardises importing of module rather than functions across all tests.