### PR TITLE
feature: Returns just dictionary when loading .topostats

### DIFF
--- a/AFMReader/topostats.py
+++ b/AFMReader/topostats.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from pathlib import Path
+from typing import Any
 
 import h5py
 
@@ -11,7 +12,7 @@ from AFMReader.io import unpack_hdf5
 logger.enable(__package__)
 
 
-def load_topostats(file_path: Path | str) -> tuple:
+def load_topostats(file_path: Path | str) -> dict[str, Any]:
     """
     Extract image and pixel to nm scaling from the .topostats (HDF5 format) file.
 
@@ -22,9 +23,9 @@ def load_topostats(file_path: Path | str) -> tuple:
 
     Returns
     -------
-    tuple(np.ndarray, float)
-        A tuple containing the image, its pixel to nm scaling factor and the data dictionary
-        containing all the extra image data and metadata in dictionary format.
+    dict[str, Any]
+        A dictionary containing the image, its pixel to nm scaling factor and nested Numpy arrays representing the
+        analyses performed on the data.
 
     Raises
     ------
@@ -45,12 +46,10 @@ def load_topostats(file_path: Path | str) -> tuple:
                 data["img_path"] = Path(data["img_path"])
             file_version = data["topostats_file_version"]
             logger.info(f"[{filename}] TopoStats file version : {file_version}")
-            image = data["image"]
-            pixel_to_nm_scaling = data["pixel_to_nm_scaling"]
 
     except OSError as e:
         if "Unable to open file" in str(e):
             logger.error(f"[{filename}] File not found : {file_path}")
         raise e
 
-    return (image, pixel_to_nm_scaling, data)
+    return data

--- a/tests/test_topostats.py
+++ b/tests/test_topostats.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 import pytest
 
-import numpy as np
 
 from AFMReader import topostats
 
@@ -55,27 +54,22 @@ RESOURCES = BASE_DIR / "tests" / "resources"
 def test_load_topostats(
     file_name: str,
     topostats_file_version: float,
-    image_shape: tuple[int, int],
+    image_shape: tuple,
     pixel_to_nm_scaling: float,
     data_keys: set[str],
     image_sum: float,
 ) -> None:
     """Test the normal operation of loading a .topostats (HDF5 format) file."""
-    result_image = np.ndarray
-    result_pixel_to_nm_scaling = float
-    result_data = dict
-
     file_path = RESOURCES / file_name
-    result_image, result_pixel_to_nm_scaling, result_data = topostats.load_topostats(file_path)
+    topostats_data = topostats.load_topostats(file_path)
 
-    assert result_pixel_to_nm_scaling == pixel_to_nm_scaling
-    assert isinstance(result_image, np.ndarray)
-    assert result_image.shape == image_shape
-    assert set(result_data.keys()) == data_keys  # type: ignore
-    assert result_data["topostats_file_version"] == topostats_file_version
-    assert result_image.sum() == image_sum
+    assert set(topostats_data.keys()) == data_keys  # type: ignore
+    assert topostats_data["topostats_file_version"] == topostats_file_version
+    assert topostats_data["pixel_to_nm_scaling"] == pixel_to_nm_scaling
+    assert topostats_data["image"].shape == image_shape
+    assert topostats_data["image"].sum() == image_sum
     if topostats_file_version >= 0.2:
-        assert isinstance(result_data["img_path"], Path)
+        assert isinstance(topostats_data["img_path"], Path)
 
 
 def test_load_topostats_file_not_found() -> None:


### PR DESCRIPTION
Closes #109

Rather than return the HDF5 object loaded from `.topostats` as a dictionary as the third item in a tuple along with the
`image` and `pixel_to_nm_scaling` (both of which are extracted from the loaded data anyway) just the dictionary is
returned. This matches the structure of objects created by TopoStats and how they are saved to HDF5 files.