### PR TITLE
Scaling JPK data values correctly

### DIFF
--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -85,13 +85,13 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
     for slot, values in slots.items():
         for value in values:
             if tif.pages[channel_idx].tags[str(value)].value == default_slot.value:
-                default_slot_number = slot
+                _default_slot = slot
 
     # Determine if the default slot requires scaling and find scaling and offset values
-    scaling_type = tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_scaling_type"]) + (48 * (default_slot_number)))].value
+    scaling_type = tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_scaling_type"]) + (48 * (_default_slot)))].value
     if scaling_type == "LinearScaling":
-        scaling_name = tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_scaling_name"]) + (48 * (default_slot_number)))].name
-        offset_name = tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_offset_name"]) + (48 * (default_slot_number)))].name
+        scaling_name = tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_scaling_name"]) + (48 * (_default_slot)))].name
+        offset_name = tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_offset_name"]) + (48 * (_default_slot)))].name
         scaling = tif.pages[channel_idx].tags[scaling_name].value
         offset = tif.pages[channel_idx].tags[offset_name].value
     elif scaling_type == "NullScaling":

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -91,16 +91,12 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
 
     # Determine if the default slot requires scaling and find scaling and offset values
 
-    scaling_type = (
-        tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_scaling_type"]) + (48 * (_default_slot)))].value
-    )
+    scaling_type = tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_scaling_type"]) + (48 * (_default_slot)))].value
     if scaling_type == "LinearScaling":
         scaling_name = (
             tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_scaling_name"]) + (48 * (_default_slot)))].name
         )
-        offset_name = (
-            tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_offset_name"]) + (48 * (_default_slot)))].name
-        )
+        offset_name = tif.pages[channel_idx].tags[str(int(JPK_TAGS["first_offset_name"]) + (48 * (_default_slot)))].name
 
         scaling = tif.pages[channel_idx].tags[scaling_name].value
         offset = tif.pages[channel_idx].tags[offset_name].value

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -45,6 +45,8 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
     ----------
     tif : tifffile.tifffile
         A tiff file of .jpk images.
+    channel_idx : int
+        Numerical channel identifier used to navigate the tifffile pages.
 
     Returns
     -------

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -50,14 +50,14 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
 
     Returns
     -------
-    tuple
+    tuple[float, float]
         A tuple contains values used to scale and offset raw data.
     """
     n_slots = tif.pages[channel_idx].tags["32896"].value
     default_slot = tif.pages[channel_idx].tags["32897"]
 
     # Create a dictionary of list for the differnt slots
-    slots = {slot: [] for slot in range(n_slots)}
+    slots: Dict[int, List] = {slot: [] for slot in range(n_slots)}
 
     # Extract the tags with numerical names in each slot
     while n_slots >= 0:

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -51,7 +51,7 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
     tuple
         A tuple contains values used to scale and offset raw data.
     """
-    NrOfSlots = tif.pages[channel_idx].tags["32896"].value
+    n_slots = tif.pages[channel_idx].tags["32896"].value
     default_slot = tif.pages[channel_idx].tags["32897"]
 
     # Create a dictionary of list for the differnt slots

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -34,10 +34,11 @@ def _jpk_pixel_to_nm_scaling(tiff_page: tifffile.tifffile.TiffPage) -> float:
 
     return px_to_nm * 1e9
 
+
 def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, float]:
     """
-    Extract the z scaling factor and offset for a JPK image channel. 
-    
+    Extract the z scaling factor and offset for a JPK image channel.
+
     Determined using JPKImageSpec.txt Version: 2.0:3fffffffffff supplied with JPK instrument.
 
     Parameters
@@ -53,12 +54,12 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
     NrOfSlots = tif.pages[channel_idx].tags["32896"].value
     default_slot = tif.pages[channel_idx].tags["32897"]
 
-    #Create a dictionary of list for the differnt slots
+    # Create a dictionary of list for the differnt slots
     slots = {}
-    for slot in range (NrOfSlots):
+    for slot in range(NrOfSlots):
         slots[slot + 1] = []
 
-    #Extract the tags with numerical names in each slot
+    # Extract the tags with numerical names in each slot
     while NrOfSlots >= 1:
         for tag in tif.pages[channel_idx].tags:
             try:
@@ -69,14 +70,14 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
                 continue
         NrOfSlots -= 1
 
-    #Find the number of the default slot (selected in the instrument GUI) 
+    # Find the number of the default slot (selected in the instrument GUI)
     for slot_name, values in slots.items():
         for value in values:
             if tif.pages[channel_idx].tags[str(value)].value == default_slot.value:
                 default_slot_number = slot_name
 
-    #Determine if the default slot requires scaling and find scaling and offset values
-    scaling_type = tif.pages[channel_idx].tags[str(32931 + (48 * (default_slot_number-1)))].value
+    # Determine if the default slot requires scaling and find scaling and offset values
+    scaling_type = tif.pages[channel_idx].tags[str(32931 + (48 * (default_slot_number - 1)))].value
     scaling_name = tif.pages[channel_idx].tags[str(32932 + (48 * (default_slot_number - 1)))].name
     offset_name = tif.pages[channel_idx].tags[str(32933 + (48 * (default_slot_number - 1)))].name
     if scaling_type == "LinearScaling":
@@ -149,7 +150,7 @@ def load_jpk(file_path: Path | str, channel: str) -> tuple[np.ndarray, float]:
     scaling, offset = _get_z_scaling(tif, channel_idx)
     image = (image * scaling) + offset
 
-    if channel_page.tags['32848'].value in ('height', 'measuredHeight', 'amplitude'):
+    if channel_page.tags["32848"].value in ("height", "measuredHeight", "amplitude"):
         image = image * 1e9
 
     # Get page for common metadata between scans

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -57,7 +57,7 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
     default_slot = tif.pages[channel_idx].tags["32897"]
 
     # Create a dictionary of list for the differnt slots
-    slots = {slot: [] for slot in range(n_slots)}
+    slots dict[int, list[str]] = {slot: [] for slot in range(n_slots)}
 
     # Extract the tags with numerical names in each slot
     while n_slots >= 0:
@@ -78,9 +78,9 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
 
     # Determine if the default slot requires scaling and find scaling and offset values
     scaling_type = tif.pages[channel_idx].tags[str(32931 + (48 * (default_slot_number)))].value
-    scaling_name = tif.pages[channel_idx].tags[str(32932 + (48 * (default_slot_number)))].name
-    offset_name = tif.pages[channel_idx].tags[str(32933 + (48 * (default_slot_number)))].name
     if scaling_type == "LinearScaling":
+        scaling_name = tif.pages[channel_idx].tags[str(32932 + (48 * (default_slot_number)))].name
+        offset_name = tif.pages[channel_idx].tags[str(32933 + (48 * (default_slot_number)))].name
         scaling = tif.pages[channel_idx].tags[scaling_name].value
         offset = tif.pages[channel_idx].tags[offset_name].value
     elif scaling_type == "NullScaling":

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -19,6 +19,10 @@ JPK_TAGS = {
     "first_offset_name": "32933",
     "channel_name": "32848",
     "trace_retrace": "32849",
+    "grid_ulength" : "32834",
+    "grid_vlength" : "32835",
+    "grid_ilength" : "32838",
+    "grid_jlength" : "32839"
 }
 
 
@@ -36,10 +40,10 @@ def _jpk_pixel_to_nm_scaling(tiff_page: tifffile.tifffile.TiffPage) -> float:
     float
         A value corresponding to the real length of a single pixel.
     """
-    length = tiff_page.tags["32834"].value  # Grid-uLength (fast)
-    width = tiff_page.tags["32835"].value  # Grid-vLength (slow)
-    length_px = tiff_page.tags["32838"].value  # Grid-iLength (fast)
-    width_px = tiff_page.tags["32839"].value  # Grid-jLength (slow)
+    length = tiff_page.tags[JPK_TAGS["grid_ulength"]].value  # Grid-uLength (fast)
+    width = tiff_page.tags[JPK_TAGS["grid_vlength"]].value  # Grid-vLength (slow)
+    length_px = tiff_page.tags[JPK_TAGS["grid_ilength"]].value  # Grid-iLength (fast)
+    width_px = tiff_page.tags[JPK_TAGS["grid_jlength"]].value  # Grid-jLength (slow)
 
     px_to_nm = (length / length_px, width / width_px)[0]
 

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -64,8 +64,8 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
         for tag in tif.pages[channel_idx].tags:
             try:
                 tag_name_float = float(tag.name)
-                if tag_name_float >= (32912 + ((n_slots - 1) * 48)) and tag_name_float < (32912 + (n_slots * 48)):
-                    slots[n_slots].append(tag.name)
+                if tag_name_float >= (32912 + (n_slots * 48)) and tag_name_float < (32912 + ((n_slots + 1) * 48)):
+                    slots[(n_slots)].append(tag.name)
             except ValueError:
                 continue
         n_slots -= 1

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -57,7 +57,7 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
     default_slot = tif.pages[channel_idx].tags["32897"]
 
     # Create a dictionary of list for the differnt slots
-    slots: Dict[int, List] = {slot: [] for slot in range(n_slots)}
+    slots = {slot: [] for slot in range(n_slots)}
 
     # Extract the tags with numerical names in each slot
     while n_slots >= 0:

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -10,6 +10,14 @@ from AFMReader.logging import logger
 
 logger.enable(__package__)
 
+JPK_TAGS = {
+  "n_slots": "32896",
+  "default": "32897",
+  "tag_name": "32912",
+  "first_scaling_type": "32931",
+  "first_scaling_name": "32932",
+  "first_offset_name": "32933",
+}
 
 def _jpk_pixel_to_nm_scaling(tiff_page: tifffile.tifffile.TiffPage) -> float:
     """
@@ -57,7 +65,7 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
     default_slot = tif.pages[channel_idx].tags["32897"]
 
     # Create a dictionary of list for the differnt slots
-    slots dict[int, list[str]] = {slot: [] for slot in range(n_slots)}
+    slots: dict[int, list[str]] = {slot: [] for slot in range(n_slots)}
 
     # Extract the tags with numerical names in each slot
     while n_slots >= 0:

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -55,31 +55,29 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int) -> tuple[float, flo
     default_slot = tif.pages[channel_idx].tags["32897"]
 
     # Create a dictionary of list for the differnt slots
-    slots = {}
-    for slot in range(NrOfSlots):
-        slots[slot + 1] = []
+    slots = {slot: [] for slot in range(n_slots)}
 
     # Extract the tags with numerical names in each slot
-    while NrOfSlots >= 1:
+    while n_slots >= 0:
         for tag in tif.pages[channel_idx].tags:
             try:
                 tag_name_float = float(tag.name)
-                if tag_name_float >= (32912 + ((NrOfSlots - 1) * 48)) and tag_name_float < (32912 + (NrOfSlots * 48)):
-                    slots[NrOfSlots].append(tag.name)
+                if tag_name_float >= (32912 + ((n_slots - 1) * 48)) and tag_name_float < (32912 + (n_slots * 48)):
+                    slots[n_slots].append(tag.name)
             except ValueError:
                 continue
-        NrOfSlots -= 1
+        n_slots -= 1
 
     # Find the number of the default slot (selected in the instrument GUI)
-    for slot_name, values in slots.items():
+    for slot, values in slots.items():
         for value in values:
             if tif.pages[channel_idx].tags[str(value)].value == default_slot.value:
-                default_slot_number = slot_name
+                default_slot_number = slot
 
     # Determine if the default slot requires scaling and find scaling and offset values
-    scaling_type = tif.pages[channel_idx].tags[str(32931 + (48 * (default_slot_number - 1)))].value
-    scaling_name = tif.pages[channel_idx].tags[str(32932 + (48 * (default_slot_number - 1)))].name
-    offset_name = tif.pages[channel_idx].tags[str(32933 + (48 * (default_slot_number - 1)))].name
+    scaling_type = tif.pages[channel_idx].tags[str(32931 + (48 * (default_slot_number)))].value
+    scaling_name = tif.pages[channel_idx].tags[str(32932 + (48 * (default_slot_number)))].name
+    offset_name = tif.pages[channel_idx].tags[str(32933 + (48 * (default_slot_number)))].name
     if scaling_type == "LinearScaling":
         scaling = tif.pages[channel_idx].tags[scaling_name].value
         offset = tif.pages[channel_idx].tags[offset_name].value

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -19,10 +19,10 @@ JPK_TAGS = {
     "first_offset_name": "32933",
     "channel_name": "32848",
     "trace_retrace": "32849",
-    "grid_ulength" : "32834",
-    "grid_vlength" : "32835",
-    "grid_ilength" : "32838",
-    "grid_jlength" : "32839"
+    "grid_ulength": "32834",
+    "grid_vlength": "32835",
+    "grid_ilength": "32838",
+    "grid_jlength": "32839",
 }
 
 

--- a/examples/example_01.ipynb
+++ b/examples/example_01.ipynb
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load the IBW file as an image and pixel to nm scaling factor\n",
+    "# Load the JPK file as an image and pixel to nm scaling factor\n",
     "FILE = \"../tests/resources/sample_0.jpk\"\n",
     "image, pixel_to_nm_scaling = load_jpk(file_path=FILE, channel=\"height_trac\")"
    ]

--- a/tests/test_jpk.py
+++ b/tests/test_jpk.py
@@ -15,7 +15,7 @@ RESOURCES = BASE_DIR / "tests" / "resources"
     ("file_name", "channel", "pixel_to_nm_scaling", "image_shape", "image_dtype", "image_sum"),
     [
         pytest.param(
-            "sample_0.jpk", "height_trace", 1.2770176335964876, (256, 256), float, 286598232.9308627, id="test image 0"
+            "sample_0.jpk", "height_trace", 1.2770176335964876, (256, 256), float, 219242202.8256843, id="test image 0"
         )
     ],
 )


### PR DESCRIPTION
As described in issue #116, currently the data (z values) scaling factors used for most channels in JPK images are incorrect and some channels cannot be read.

This pull request creates the fucntion `_get_z_scaling()` that extracts the correct scaling factor for each channel and uses these to scale the image.

Additonally corrects a typo in the example notebook.

This fixes #116 