### PR TITLE
feature: introduce config file for JPK tags

### DIFF
--- a/AFMReader/default_config.yaml
+++ b/AFMReader/default_config.yaml
@@ -11,3 +11,4 @@ jpk:
   grid_vlength: 32835
   grid_ilength: 32838
   grid_jlength: 32839
+  slot_size: 48

--- a/AFMReader/default_config.yaml
+++ b/AFMReader/default_config.yaml
@@ -1,0 +1,13 @@
+jpk:
+  n_slots: 32896
+  default_slot: 32897
+  first_slot_tag: 32912
+  first_scaling_type: 32931
+  first_scaling_name: 32932
+  first_offset_name: 32933
+  channel_name: 32848
+  trace_retrace: 32849
+  grid_ulength: 32834
+  grid_vlength: 32835
+  grid_ilength: 32838
+  grid_jlength: 32839

--- a/AFMReader/io.py
+++ b/AFMReader/io.py
@@ -1,9 +1,13 @@
 """For reading and writing data from / to files."""
 
+from __future__ import annotations
+from pathlib import Path
+
 import struct
 from typing import BinaryIO
 import h5py
 from loguru import logger
+from ruamel.yaml import YAML, YAMLError
 
 
 def read_uint8(open_file: BinaryIO) -> int:
@@ -315,3 +319,26 @@ def read_char(open_file: BinaryIO) -> str:
         A string type cast from the decoded character.
     """
     return open_file.read(1).decode("ascii")
+
+
+def read_yaml(filename: str | Path) -> dict:
+    """
+    Read a YAML file.
+
+    Parameters
+    ----------
+    filename : Union[str, Path]
+        YAML file to read.
+
+    Returns
+    -------
+    Dict
+        Dictionary of the file.
+    """
+    with Path(filename).open(encoding="utf-8") as f:
+        try:
+            yaml_file = YAML(typ="safe")
+            return yaml_file.load(f)
+        except YAMLError as exception:
+            logger.error(exception)
+            return {}

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -74,8 +74,8 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int, jpk_tags: dict[str,
             try:
                 tag_name_float = float(tag.name)
                 if tag_name_float >= (  # pylint: disable=chained-comparison
-                    int(jpk_tags["first_slot_tag"]) + (n_slots * 48)
-                ) and tag_name_float < (int(jpk_tags["first_slot_tag"]) + ((n_slots + 1) * 48)):
+                    int(jpk_tags["first_slot_tag"]) + (n_slots * jpk_tags["slot_size"])
+                ) and tag_name_float < (int(jpk_tags["first_slot_tag"]) + ((n_slots + 1) * jpk_tags["slot_size"])):
                     slots[(n_slots)].append(tag.name)
             except ValueError:
                 continue
@@ -88,12 +88,22 @@ def _get_z_scaling(tif: tifffile.tifffile, channel_idx: int, jpk_tags: dict[str,
                 _default_slot = slot
 
     # Determine if the default slot requires scaling and find scaling and offset values
-    scaling_type = tif.pages[channel_idx].tags[str(int(jpk_tags["first_scaling_type"]) + (48 * (_default_slot)))].value
+    scaling_type = (
+        tif.pages[channel_idx]
+        .tags[str(int(jpk_tags["first_scaling_type"]) + (jpk_tags["slot_size"] * (_default_slot)))]
+        .value
+    )
     if scaling_type == "LinearScaling":
         scaling_name = (
-            tif.pages[channel_idx].tags[str(int(jpk_tags["first_scaling_name"]) + (48 * (_default_slot)))].name
+            tif.pages[channel_idx]
+            .tags[str(int(jpk_tags["first_scaling_name"]) + (jpk_tags["slot_size"] * (_default_slot)))]
+            .name
         )
-        offset_name = tif.pages[channel_idx].tags[str(int(jpk_tags["first_offset_name"]) + (48 * (_default_slot)))].name
+        offset_name = (
+            tif.pages[channel_idx]
+            .tags[str(int(jpk_tags["first_offset_name"]) + (jpk_tags["slot_size"] * (_default_slot)))]
+            .name
+        )
 
         scaling = tif.pages[channel_idx].tags[scaling_name].value
         offset = tif.pages[channel_idx].tags[offset_name].value

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,23 +11,45 @@ integrate it into your workflow.
 
 ## Supported file formats
 
-| File format | Description    |
-|-------------|----------------|
-| `.asd`      | High-speed AFM |
-| `.ibw`      | [WaveMetrics](https://www.wavemetrics.com/)  |
-| `.spm`      | [Bruker's Format](https://www.bruker.com/)  |
-| `.jpk`      | [Bruker](https://www.bruker.com/) |
-| `.topostats`| [TopoStats](https://github.com/AFM-SPM/TopoStats)  |
-| `.gwy`      | [Gwydion](<http://gwyddion.net>) |
+| File format  | Description                                       |
+|--------------|---------------------------------------------------|
+| `.asd`       | High-speed AFM                                    |
+| `.ibw`       | [WaveMetrics](https://www.wavemetrics.com/)       |
+| `.spm`       | [Bruker's Format](https://www.bruker.com/)        |
+| `.jpk`       | [Bruker](https://www.bruker.com/)                 |
+| `.topostats` | [TopoStats](https://github.com/AFM-SPM/TopoStats) |
+| `.gwy`       | [Gwydion](<http://gwyddion.net>)                  |
 
 Support for the following additional formats is planned. Some of these are already supported in TopoStats and are
 awaiting refactoring to move their functionality into AFMReader these are denoted in bold below.
 
-| File format | Description                                             | Status                                     |
-|-------------|---------------------------------------------------------|--------------------------------------------|
-| `.nhf`      | [Nanosurf](https://www.nanosurf.com/en/)                | To Be Implemented.                         |
-| `.aris`     | [Imaris Oxford Instruments](https://imaris.oxinst.com/) | To Be Implemented.                         |
-| `.tiff`     | [Park Systems](https://www.parksystems.com/)            | To Be Implemented.                         |
+| File format | Description                                             | Status             |
+|-------------|---------------------------------------------------------|--------------------|
+| `.nhf`      | [Nanosurf](https://www.nanosurf.com/en/)                | To Be Implemented. |
+| `.aris`     | [Imaris Oxford Instruments](https://imaris.oxinst.com/) | To Be Implemented. |
+| `.tiff`     | [Park Systems](https://www.parksystems.com/)            | To Be Implemented. |
+
+## Configuration
+
+A default configuration is included in the package which contains options for loading different file formats. This is a
+[YAML](https://yaml.org) file with keys for each file type and the relevant key/value pair nested within. The table
+below details the current configuration options. If loading a file format supports a custom configuration file then it
+can be specified with the `config_path` parameter which should point to the location of the file.
+
+| File format | Keys                 | Default value |
+|-------------|----------------------|---------------|
+| `jpk`       | `n_slots`            | `32896`       |
+|             | `default_slot`       | `32897`       |
+|             | `first_slot_tag`     | `32912`       |
+|             | `first_scaling_type` | `32931`       |
+|             | `first_scaling_name` | `32932`       |
+|             | `first_offset_name`  | `32933`       |
+|             | `channel_name`       | `32848`       |
+|             | `trace_retrace`      | `32849`       |
+|             | `grid_ulength`       | `32834`       |
+|             | `grid_vlength`       | `32835`       |
+|             | `grid_ilength`       | `32838`       |
+|             | `grid_jlength`       | `32839`       |
 
 ## .topostats
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,6 +50,7 @@ can be specified with the `config_path` parameter which should point to the loca
 |             | `grid_vlength`       | `32835`       |
 |             | `grid_ilength`       | `32838`       |
 |             | `grid_jlength`       | `32839`       |
+|             | `slot_size`          | `48`          |
 
 ## .topostats
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,13 @@ keywords = [
 ]
 
 dependencies = [
-  "matplotlib",
-  "igor2",
-  "tifffile",
-  "pySPM",
-  "loguru",
   "h5py",
+  "igor2",
+  "loguru",
+  "matplotlib",
+  "pySPM",
+  "tifffile",
+  "ruamel.yaml",
 ]
 
 [project.optional-dependencies]

--- a/tests/resources/test.yaml
+++ b/tests/resources/test.yaml
@@ -1,0 +1,11 @@
+this: is
+a: test
+yaml: file
+numbers: 123
+logical: true
+nested:
+  something: else
+a_list:
+  - 1
+  - 2
+  - 3

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,9 +6,22 @@ import numpy as np
 import h5py
 
 
-from AFMReader.io import unpack_hdf5
+from AFMReader.io import unpack_hdf5, read_yaml
 
 # mypy: disable-error-code="index"
+
+BASE_DIR = Path.cwd()
+RESOURCES = BASE_DIR / "tests" / "resources"
+
+CONFIG = {
+    "this": "is",
+    "a": "test",
+    "yaml": "file",
+    "numbers": 123,
+    "logical": True,
+    "nested": {"something": "else"},
+    "a_list": [1, 2, 3],
+}
 
 
 def test_unpack_hdf5_all_together_group_path_default(tmp_path: Path) -> None:
@@ -187,3 +200,10 @@ def test_unpack_hdf5_nested_dict_group_path(tmp_path: Path) -> None:
         result = unpack_hdf5(open_hdf5_file=f, group_path=group_path)
 
     np.testing.assert_equal(result, expected)
+
+
+def test_read_yaml() -> None:
+    """Test reading of YAML file."""
+    sample_config = read_yaml(RESOURCES / "test.yaml")
+
+    assert sample_config == CONFIG


### PR DESCRIPTION
Off the back of #118 (thanks @derollins) I've parameterised the JPK tags that were introduced into
`AFMReader/default_config.yaml` and load these by default when using `AFMReader.load_jpk()`. A parameter is introduced
to that function (`confi_path`) which allows users to specify their own configuration file should they wish to use alternative tags.

- Copies the `read_yaml()` function and tests from TopoStats.
- Brief description of configuration file and structure added to `docs/usage.md` (where some tables were also aligned by
  Emacs).

Exiting `tests/test_jpk.py` pass.

I envisage this being an extensible and flexible way of users being able to handle parameters changing the array of file types that 
exist now and in the future and it should be easy to extend to other file formats.