### PR TITLE
tests(topostats): Compare versions as strings

### DIFF
--- a/AFMReader/topostats.py
+++ b/AFMReader/topostats.py
@@ -42,7 +42,7 @@ def load_topostats(file_path: Path | str) -> dict[str, Any]:
     try:
         with h5py.File(file_path, "r") as f:
             data = unpack_hdf5(open_hdf5_file=f, group_path="/")
-            if data["topostats_file_version"] >= 0.2:
+            if str(data["topostats_file_version"]) >= "0.2":
                 data["img_path"] = Path(data["img_path"])
             file_version = data["topostats_file_version"]
             logger.info(f"[{filename}] TopoStats file version : {file_version}")


### PR DESCRIPTION
Compares versions of `.topostats` as strings with a view to moving to storing the version of TopoStats that `.topostats` files were created in as a field in the HDF5 `.topostats` file itself.

Strings seem to be compared logically...

```python
In [1]import topostats

In [2]: topostats.__release__
Out[2]: '2.3.2'

In [3]: topostats.__release__ > "0.2"
Out[3]: True

In [4]: "0.2.1" > "0.2"
Out[4]: True

In [5]: "0.2.0" >= "0.2"
Out[5]: True
```