### PR TITLE
tests: Adds pytest-loguru to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ pypi = [
 tests = [
   "pytest",
   "pytest-cov",
+  "pytest-loguru",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,26 +4,10 @@ from pathlib import Path
 
 import pySPM
 import pytest
-from _pytest.logging import LogCaptureFixture
 
-from AFMReader.logging import logger
 
 BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests" / "resources"
-
-
-@pytest.fixture()
-def caplog(caplog: LogCaptureFixture):  # pylint: disable=redefined-outer-name
-    """Instantiate the logging capture for loguru."""
-    handler_id = logger.add(
-        caplog.handler,
-        format="{message}",
-        level=0,
-        filter=lambda record: record["level"].no >= caplog.handler.level,
-        enqueue=False,  # Set to 'True' if your test is spawning child processes.
-    )
-    yield caplog
-    logger.remove(handler_id)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Further to [previous review](https://github.com/AFM-SPM/AFMReader/pull/131#discussion_r2044558273) this replaces the redefinitions of `caplog` with the [pytest-loguru extension](https://github.com/mcarans/pytest-loguru).