### PR TITLE
tests: make topostats tests flexible to key name

### DIFF
--- a/tests/test_topostats.py
+++ b/tests/test_topostats.py
@@ -9,13 +9,24 @@ from AFMReader import topostats
 BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests" / "resources"
 
+# pylint: disable=too-many-positional-arguments
+
 
 @pytest.mark.parametrize(
-    ("file_name", "topostats_file_version", "image_shape", "pixel_to_nm_scaling", "data_keys", "image_sum"),
+    (
+        "file_name",
+        "version_key",
+        "version",
+        "image_shape",
+        "pixel_to_nm_scaling",
+        "data_keys",
+        "image_sum",
+    ),
     [
         pytest.param(
             "sample_0_1.topostats",
-            0.1,
+            "topostats_file_version",
+            "0.1",
             (64, 64),
             1.97601171875,
             {
@@ -28,7 +39,8 @@ RESOURCES = BASE_DIR / "tests" / "resources"
         ),
         pytest.param(
             "sample_0_2.topostats",
-            0.2,
+            "topostats_file_version",
+            "0.2",
             (64, 64),
             1.97601171875,
             {
@@ -49,11 +61,27 @@ RESOURCES = BASE_DIR / "tests" / "resources"
             1176.601500471239,
             id="version 0.2",
         ),
+        pytest.param(
+            "sample_2_3_2.topostats",
+            "topostats_version",
+            "2.3.2",
+            (64, 64),
+            1.97601171875,
+            {
+                "pixel_to_nm_scaling",
+                "image",
+                "topostats_version",
+            },
+            112069.51332503435,
+            id="version 2.3.2",
+            marks=pytest.mark.xfail(reason="Not yet implemented"),
+        ),
     ],
 )
 def test_load_topostats(
     file_name: str,
-    topostats_file_version: float,
+    version_key: str,
+    version: str,
     image_shape: tuple,
     pixel_to_nm_scaling: float,
     data_keys: set[str],
@@ -64,11 +92,14 @@ def test_load_topostats(
     topostats_data = topostats.load_topostats(file_path)
 
     assert set(topostats_data.keys()) == data_keys  # type: ignore
-    assert topostats_data["topostats_file_version"] == topostats_file_version
+    if version_key == "topostats_file_version":
+        assert topostats_data[version_key] == float(version)
+    else:
+        assert topostats_data[version_key] == version
     assert topostats_data["pixel_to_nm_scaling"] == pixel_to_nm_scaling
     assert topostats_data["image"].shape == image_shape
     assert topostats_data["image"].sum() == image_sum
-    if topostats_file_version >= 0.2:
+    if version >= "0.2":
         assert isinstance(topostats_data["img_path"], Path)
 
 


### PR DESCRIPTION
We are going to switch from having the `topostats_file_version` as the name for the metadata that `.topostats` files
were generated with to using the `topostats_version` as key which will align with the release tag and make it easier for
work to be reproducible.

This small commit adds the `version_key` variable to the `tests/test_topostats.py::test_load_topostats()` test so that
the key against which tests are made will work with old versions and future versions.