### PR TITLE
Add general loader module

### DIFF
--- a/AFMReader/asd.py
+++ b/AFMReader/asd.py
@@ -33,8 +33,7 @@ if sys.version_info.minor < 11:
     from typing import Any, BinaryIO
     from typing_extensions import Self
 else:
-    from typing import Any, BinaryIO
-    from typing_extensions import Self
+    from typing import Any, BinaryIO, Self
 
 
 logger.enable(__package__)

--- a/AFMReader/asd.py
+++ b/AFMReader/asd.py
@@ -33,7 +33,8 @@ if sys.version_info.minor < 11:
     from typing import Any, BinaryIO
     from typing_extensions import Self
 else:
-    from typing import Any, BinaryIO, Self
+    from typing import Any, BinaryIO
+    from typing_extensions import Self
 
 
 logger.enable(__package__)
@@ -262,7 +263,7 @@ def load_asd(file_path: str | Path, channel: str):
             _ = open_file.read(length_of_all_first_channel_frames)
         else:
             raise ValueError(
-                f"Channel {channel} not found in this file's available channels: "
+                f"'{channel}' not found {file_path.suffix} channel list: "
                 f"{header_dict['channel1']}, {header_dict['channel2']}"
             )
 

--- a/AFMReader/asd.py
+++ b/AFMReader/asd.py
@@ -289,6 +289,7 @@ def load_asd(file_path: str | Path, channel: str):
 
         frames = np.array(frames)
 
+        logger.info(f"[{filename}] : Extracted image.")
         return frames, pixel_to_nanometre_scaling_factor, header_dict
 
 

--- a/AFMReader/general_loader.py
+++ b/AFMReader/general_loader.py
@@ -69,10 +69,12 @@ class LoadFile:
             elif self.suffix == ".topostats":
                 ts_dict = topostats.load_topostats(self.filepath)
                 try:
-                    image = ts_dict["image"]
-                except KeyError:
-                    image = ts_dict["image_original"]
-                pixel_to_nanometre_scaling_factor = ts_dict["pixel_to_nm_scaling"]
+                    image = ts_dict[self.channel]
+                    pixel_to_nanometre_scaling_factor = ts_dict["pixel_to_nm_scaling"]
+                except KeyError as exc:
+                    image_keys = ["image", "image_original"]
+                    topostats_keys = list(ts_dict.keys())
+                    raise ValueError(f"'{self.channel}' not in available image keys: {[im for im in image_keys if im in topostats_keys]}") from exc
             else:
                 raise ValueError(f"File type '{self.suffix}' is not currently handled by AFMReader.")
 

--- a/AFMReader/general_loader.py
+++ b/AFMReader/general_loader.py
@@ -36,7 +36,7 @@ class LoadFile:
         self.channel = channel
         self.suffix = filepath.suffix
 
-    def load(self):  # noqa: C901
+    def load(self) -> tuple[npt.NDArray | str, float | None]:  # noqa: C901
         """
         Generally loads a file type that can be handled by AFMReader.
 

--- a/AFMReader/general_loader.py
+++ b/AFMReader/general_loader.py
@@ -1,0 +1,85 @@
+"""Switchboard for input files."""
+
+from pathlib import Path
+
+from AFMReader import asd, gwy, ibw, jpk, spm, stp, top, topostats
+from AFMReader.logging import logger
+
+logger.enable(__package__)
+
+
+# pylint: disable=too-few-public-methods
+class LoadFile:
+    """
+    Class to handle the general loading of an AFM file.
+
+    Parameters
+    ----------
+        filepath : Path
+            Path to the AFM image.
+        channel : str
+            Channel to extract from the AFM image.
+    """
+
+    def __init__(self, filepath: Path, channel: str):
+        """
+        Initialise the general LoadFile class with a filepath and channel.
+
+        Parameters
+        ----------
+        filepath : Path
+            Path to the AFM image.
+        channel : str
+            Channel to extract from the AFM image.
+        """
+        self.filepath = filepath
+        self.channel = channel
+        self.suffix = filepath.suffix
+
+    def load(self):  # noqa: C901
+        """
+        Generally loads a file type that can be handled by AFMReader.
+
+        Returns
+        -------
+        tuple
+            The image data (stack if .asd) and the pixel to nanometre scaling ratio.
+
+        Raises
+        ------
+        ValueError
+            Where the channel is not found, returned as a tuple of "error message" and "None" so that this can be
+            propagated to Napari without outright failing.
+        """
+        try:
+            if self.suffix == ".asd":
+                image, pixel_to_nanometre_scaling_factor, _ = asd.load_asd(self.filepath, self.channel)
+            elif self.suffix == ".gwy":
+                image, pixel_to_nanometre_scaling_factor = gwy.load_gwy(self.filepath, self.channel)
+            elif self.suffix == ".ibw":
+                image, pixel_to_nanometre_scaling_factor = ibw.load_ibw(self.filepath, self.channel)
+            elif self.suffix == ".jpk":
+                image, pixel_to_nanometre_scaling_factor = jpk.load_jpk(self.filepath, self.channel)
+            elif self.suffix == ".spm":
+                image, pixel_to_nanometre_scaling_factor = spm.load_spm(self.filepath, self.channel)
+            elif self.suffix == ".stp":
+                image, pixel_to_nanometre_scaling_factor = stp.load_stp(self.filepath)
+            elif self.suffix == ".top":
+                image, pixel_to_nanometre_scaling_factor = top.load_top(self.filepath)
+            elif self.suffix == ".topostats":
+                ts_dict = topostats.load_topostats(self.filepath)
+                try:
+                    image = ts_dict["image"]
+                except KeyError:
+                    image = ts_dict["image_original"]
+                pixel_to_nanometre_scaling_factor = ts_dict["pixel_to_nm_scaling"]
+            else:
+                raise ValueError(f"File type '{self.suffix}' is not currently handled by AFMReader.")
+
+            return image, pixel_to_nanometre_scaling_factor
+
+        except ValueError as e:
+            logger.error(f"{e}")
+            return (e, None)  # cheeky return of an image, px2nm-like tuple object to propagate error message to Napari
+
+    # scope for a "check what channels are available" function similar to above.

--- a/AFMReader/general_loader.py
+++ b/AFMReader/general_loader.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import numpy.typing as npt
+
 from AFMReader import asd, gwy, ibw, jpk, spm, stp, top, topostats
 from AFMReader.logging import logger
 
@@ -75,7 +77,8 @@ class LoadFile:
                     image_keys = ["image", "image_original"]
                     topostats_keys = list(ts_dict.keys())
                     raise ValueError(
-                        f"'{self.channel}' not in available image keys: {[im for im in image_keys if im in topostats_keys]}"
+                        f"'{self.channel}' not in available image keys: "
+                        f"{[im for im in image_keys if im in topostats_keys]}"
                     ) from exc
             else:
                 raise ValueError(f"File type '{self.suffix}' is not currently handled by AFMReader.")

--- a/AFMReader/general_loader.py
+++ b/AFMReader/general_loader.py
@@ -1,5 +1,6 @@
 """Switchboard for input files."""
 
+from __future__ import annotations
 from pathlib import Path
 
 import numpy.typing as npt
@@ -23,20 +24,20 @@ class LoadFile:
             Channel to extract from the AFM image.
     """
 
-    def __init__(self, filepath: Path, channel: str):
+    def __init__(self, filepath: str | Path, channel: str):
         """
         Initialise the general LoadFile class with a filepath and channel.
 
         Parameters
         ----------
-        filepath : Path
+        filepath : str | Path
             Path to the AFM image.
         channel : str
             Channel to extract from the AFM image.
         """
-        self.filepath = filepath
+        self.filepath = Path(filepath)
         self.channel = channel
-        self.suffix = filepath.suffix
+        self.suffix = self.filepath.suffix
 
     def load(self) -> tuple[npt.NDArray | str, float | None]:  # noqa: C901
         """
@@ -45,7 +46,7 @@ class LoadFile:
         Returns
         -------
         tuple
-            The image data (stack if .asd) and the pixel to nanometre scaling ratio.
+            The image data (stack if ''.asd'') and the pixel to nanometre scaling ratio.
 
         Raises
         ------

--- a/AFMReader/gwy.py
+++ b/AFMReader/gwy.py
@@ -63,7 +63,7 @@ def load_gwy(file_path: Path | str, channel: str) -> tuple[np.ndarray[Any, np.dt
         channel_ids = gwy_get_channels(gwy_file_structure=image_data_dict)
 
         if channel not in channel_ids:
-            raise KeyError(f"Channel {channel} not found in {file_path.suffix} channel list: {channel_ids}")
+            raise KeyError(f"Channel '{channel}' not found in {file_path.suffix} channel list: {channel_ids}")
 
         # Get the image data
         image = image_data_dict[f"/{channel_ids[channel]}/data"]["data"]
@@ -85,6 +85,9 @@ def load_gwy(file_path: Path | str, channel: str) -> tuple[np.ndarray[Any, np.dt
     except FileNotFoundError:
         logger.info(f"[{filename}] File not found : {file_path}")
         raise
+    except KeyError as e:
+        logger.error(f"[{filename}] : '{channel}' not found in {file_path.suffix} channel list: {channel_ids}")
+        raise ValueError(f"'{channel}' not found in {file_path.suffix} channel list: {channel_ids}") from e
 
     return (image, px_to_nm)
 

--- a/AFMReader/gwy.py
+++ b/AFMReader/gwy.py
@@ -89,6 +89,7 @@ def load_gwy(file_path: Path | str, channel: str) -> tuple[np.ndarray[Any, np.dt
         logger.error(f"[{filename}] : '{channel}' not found in {file_path.suffix} channel list: {channel_ids}")
         raise ValueError(f"'{channel}' not found in {file_path.suffix} channel list: {channel_ids}") from e
 
+    logger.info(f"[{filename}] : Extracted image.")
     return (image, px_to_nm)
 
 

--- a/AFMReader/ibw.py
+++ b/AFMReader/ibw.py
@@ -93,9 +93,9 @@ def load_ibw(file_path: Path | str, channel: str) -> tuple[np.ndarray, float]:
     except FileNotFoundError:
         logger.error(f"[{filename}] File not found : {file_path}")
         raise
-    except ValueError:
-        logger.error(f"[{filename}] : {channel} not in {file_path.suffix} channel list: {labels}")
-        raise
+    except ValueError as e:
+        logger.error(f"[{filename}] : '{channel}' not in {file_path.suffix} channel list: {labels}")
+        raise ValueError(f"'{channel}' not in {file_path.suffix} channel list: {labels}") from e
     except Exception as e:
         logger.error(f"[{filename}] : {e}")
         raise e

--- a/AFMReader/ibw.py
+++ b/AFMReader/ibw.py
@@ -99,5 +99,6 @@ def load_ibw(file_path: Path | str, channel: str) -> tuple[np.ndarray, float]:
     except Exception as e:
         logger.error(f"[{filename}] : {e}")
         raise e
-
+    
+    logger.info(f"[{filename}] : Extracted image.")
     return (image, _ibw_pixel_to_nm_scaling(scan))

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -227,7 +227,7 @@ def load_jpk(
         channel_idx = channel_list[channel]
     except KeyError as e:
         logger.error(f"'{channel}' not in {file_path.suffix} channel list: {channel_list}")
-        raise KeyError(f"'{channel}' not in {file_path.suffix} channel list: {channel_list}") from e
+        raise ValueError(f"'{channel}' not in {file_path.suffix} channel list: {channel_list}") from e
 
     # Get image and if applicable, scale it
     channel_page = tif.pages[channel_idx]
@@ -242,6 +242,8 @@ def load_jpk(
 
     # Get page for common metadata between scans
     metadata_page = tif.pages[0]
+
+    logger.info(f"[{filename}] : Extracted image.")
     return (image, _jpk_pixel_to_nm_scaling(metadata_page, jpk_tags))
 
 

--- a/AFMReader/jpk.py
+++ b/AFMReader/jpk.py
@@ -225,9 +225,9 @@ def load_jpk(
         channel_list[f"{available_channel}_{tr_rt}"] = i + 1
     try:
         channel_idx = channel_list[channel]
-    except KeyError:
-        logger.error(f"{channel} not in channel list: {channel_list}")
-        raise
+    except KeyError as e:
+        logger.error(f"'{channel}' not in {file_path.suffix} channel list: {channel_list}")
+        raise KeyError(f"'{channel}' not in {file_path.suffix} channel list: {channel_list}") from e
 
     # Get image and if applicable, scale it
     channel_page = tif.pages[channel_idx]

--- a/AFMReader/topostats.py
+++ b/AFMReader/topostats.py
@@ -52,4 +52,5 @@ def load_topostats(file_path: Path | str) -> dict[str, Any]:
             logger.error(f"[{filename}] File not found : {file_path}")
         raise e
 
+    logger.info(f"[{filename}] : Extracted image.")
     return data

--- a/AFMReader/topostats.py
+++ b/AFMReader/topostats.py
@@ -52,5 +52,5 @@ def load_topostats(file_path: Path | str) -> dict[str, Any]:
             logger.error(f"[{filename}] File not found : {file_path}")
         raise e
 
-    logger.info(f"[{filename}] : Extracted image.")
+    logger.info(f"[{filename}] : Extracted .topostats dictionary.")
     return data

--- a/tests/test_general_loader.py
+++ b/tests/test_general_loader.py
@@ -126,7 +126,7 @@ RESOURCES = BASE_DIR / "tests" / "resources"
         ),
     ],
 )
-def test_load(caplog: pytest.LogCaptureFixture, filepath: Path, channel: str, error: bool, message: str):
+def test_load(caplog: pytest.LogCaptureFixture, filepath: Path, channel: str, error: bool, message: str) -> None:
     """Test loading of all (asd, gwy, ibw, jpk, spm, stp, top, topostats) filetypes."""
     loader = general_loader.LoadFile(filepath, channel)
 

--- a/tests/test_general_loader.py
+++ b/tests/test_general_loader.py
@@ -1,0 +1,153 @@
+"""Test the general loader module."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import numpy as np
+import numpy.typing as npt
+from AFMReader import general_loader
+
+
+BASE_DIR = Path.cwd()
+RESOURCES = BASE_DIR / "tests" / "resources"
+
+
+@pytest.mark.parametrize(
+    ("filepath", "channel", "error", "message"),
+    [
+        pytest.param(
+            RESOURCES / "sample_0.asd",
+            "TP",
+            False,
+            "Extracted image",
+            id="'.asd' success.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.asd",
+            "notherelol",
+            True,
+            "'notherelol' not found .asd channel list: TP, PH",
+            id="'asd' channel not found."
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.gwy",
+            "ZSensor",
+            False,
+            "Extracted image",
+            id="'.gwy' success.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.gwy",
+            "SenZor",
+            True,
+            "'SenZor' not found in .gwy channel list: {'ZSensor': '0', 'Peak Force Error': '1', 'Stiffness': '2', 'LogStiffness': '3', 'Adhesion': '4', 'Deformation': '5', 'Dissipation': '6', 'Height': '7'}",
+            id="'.gwy' channel not found.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.ibw",
+            "HeightTracee",
+            False,
+            "Extracted image",
+            id="'.ibw' success.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.ibw",
+            "Hight",
+            True,
+            "'Hight' not in .ibw channel list: ['HeightTracee', 'HeightRetrace', 'ZSensorTrace', 'ZSensorRetrace', 'UserIn0Trace', 'UserIn0Retrace', 'UserIn1Trace', 'UserIn1Retrace']",
+            id="'.ibw' channel not found.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.jpk",
+            "height_trace",
+            False,
+            "Extracted image",
+            id="'.jpk' success.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.jpk",
+            "might_base",
+            True,
+            "'might_base' not in .jpk channel list: {'height_retrace': 1, 'measuredHeight_retrace': 2, 'amplitude_retrace': 3, 'phase_retrace': 4, 'error_retrace': 5, 'height_trace': 6, 'measuredHeight_trace': 7, 'amplitude_trace': 8, 'phase_trace': 9, 'error_trace': 10}",
+            id="'.jpk' channel not found.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.spm",
+            "Height",
+            False,
+            "Extracted channel Height",
+            id="'.spm' success.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.spm",
+            "Force",
+            True,
+            "'Force' not in .spm channel list: ['Height Sensor', 'Peak Force Error', 'DMTModulus', 'LogDMTModulus', 'Adhesion', 'Deformation', 'Dissipation', 'Height']",
+            id="'.spm' channel not found.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.stp",
+            "",
+            False,
+            "Extracted image",
+            id="'.stp' success.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.top",
+            "",
+            False,
+            "Extracted image",
+            id="'.top' success.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0_1.topostats",
+            "",
+            False,
+            "Extracted image",
+            id="'.topostats' success.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0.xxx",
+            "NotAChannel",
+            True,
+            "File type '.xxx' is not currently handled by AFMReader.",
+            id="'.xxx' unsupported filetype.",
+        ),
+    ]
+
+)
+def test_load(caplog: pytest.LogCaptureFixture, filepath: Path, channel: str, error: bool, message: str):
+    """Test loading of all (asd, gwy, ibw, jpk, spm, stp, top, topostats) filetypes."""
+    loader = general_loader.LoadFile(filepath, channel)
+
+    image, px2nm = loader.load()
+
+    if not error:
+        # check array and px2nm returned
+        assert isinstance(image, np.ndarray)
+        assert isinstance(px2nm, float)
+    else:
+        # check when channel wrong
+        assert isinstance(image, ValueError)
+        assert px2nm == None
+
+    # check output logs
+    assert message in caplog.text
+
+@pytest.mark.parametrize(
+    ("filepath"),
+    [
+        pytest.param(
+            RESOURCES / "not_a_real_file.spm",
+            id="File not found error raised.",
+        ),
+    ]
+)
+def test_load_filenotfounderror(filepath: Path):
+    """Test that a file not found error is raise when filepath is wrong."""
+    loader = general_loader.LoadFile(filepath, "channel")
+
+    with pytest.raises(FileNotFoundError) as execinfo:
+        image, px2nm = loader.load()
+        assert "[not_a_real_file] FileNotFoundError" in execinfo.value

--- a/tests/test_general_loader.py
+++ b/tests/test_general_loader.py
@@ -102,10 +102,17 @@ RESOURCES = BASE_DIR / "tests" / "resources"
         ),
         pytest.param(
             RESOURCES / "sample_0_1.topostats",
-            "",
+            "image",
             False,
-            "Extracted image",
+            "Extracted .topostats dictionary.",
             id="'.topostats' success.",
+        ),
+        pytest.param(
+            RESOURCES / "sample_0_1.topostats",
+            "hgjswbweongp",
+            True,
+            "'hgjswbweongp' not in available image keys: ['image']",
+            id="'.topostats' channel not found.",
         ),
         pytest.param(
             RESOURCES / "sample_0.xxx",

--- a/tests/test_general_loader.py
+++ b/tests/test_general_loader.py
@@ -1,11 +1,9 @@
 """Test the general loader module."""
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 import numpy as np
-import numpy.typing as npt
 from AFMReader import general_loader
 
 
@@ -28,7 +26,7 @@ RESOURCES = BASE_DIR / "tests" / "resources"
             "notherelol",
             True,
             "'notherelol' not found .asd channel list: TP, PH",
-            id="'asd' channel not found."
+            id="'asd' channel not found.",
         ),
         pytest.param(
             RESOURCES / "sample_0.gwy",
@@ -41,7 +39,8 @@ RESOURCES = BASE_DIR / "tests" / "resources"
             RESOURCES / "sample_0.gwy",
             "SenZor",
             True,
-            "'SenZor' not found in .gwy channel list: {'ZSensor': '0', 'Peak Force Error': '1', 'Stiffness': '2', 'LogStiffness': '3', 'Adhesion': '4', 'Deformation': '5', 'Dissipation': '6', 'Height': '7'}",
+            "'SenZor' not found in .gwy channel list: {'ZSensor': '0', 'Peak Force Error': '1', 'Stiffness': '2', "
+            "'LogStiffness': '3', 'Adhesion': '4', 'Deformation': '5', 'Dissipation': '6', 'Height': '7'}",
             id="'.gwy' channel not found.",
         ),
         pytest.param(
@@ -55,7 +54,8 @@ RESOURCES = BASE_DIR / "tests" / "resources"
             RESOURCES / "sample_0.ibw",
             "Hight",
             True,
-            "'Hight' not in .ibw channel list: ['HeightTracee', 'HeightRetrace', 'ZSensorTrace', 'ZSensorRetrace', 'UserIn0Trace', 'UserIn0Retrace', 'UserIn1Trace', 'UserIn1Retrace']",
+            "'Hight' not in .ibw channel list: ['HeightTracee', 'HeightRetrace', 'ZSensorTrace', 'ZSensorRetrace', "
+            "'UserIn0Trace', 'UserIn0Retrace', 'UserIn1Trace', 'UserIn1Retrace']",
             id="'.ibw' channel not found.",
         ),
         pytest.param(
@@ -69,7 +69,9 @@ RESOURCES = BASE_DIR / "tests" / "resources"
             RESOURCES / "sample_0.jpk",
             "might_base",
             True,
-            "'might_base' not in .jpk channel list: {'height_retrace': 1, 'measuredHeight_retrace': 2, 'amplitude_retrace': 3, 'phase_retrace': 4, 'error_retrace': 5, 'height_trace': 6, 'measuredHeight_trace': 7, 'amplitude_trace': 8, 'phase_trace': 9, 'error_trace': 10}",
+            "'might_base' not in .jpk channel list: {'height_retrace': 1, 'measuredHeight_retrace': 2, "
+            "'amplitude_retrace': 3, 'phase_retrace': 4, 'error_retrace': 5, 'height_trace': 6, "
+            "'measuredHeight_trace': 7, 'amplitude_trace': 8, 'phase_trace': 9, 'error_trace': 10}",
             id="'.jpk' channel not found.",
         ),
         pytest.param(
@@ -83,7 +85,8 @@ RESOURCES = BASE_DIR / "tests" / "resources"
             RESOURCES / "sample_0.spm",
             "Force",
             True,
-            "'Force' not in .spm channel list: ['Height Sensor', 'Peak Force Error', 'DMTModulus', 'LogDMTModulus', 'Adhesion', 'Deformation', 'Dissipation', 'Height']",
+            "'Force' not in .spm channel list: ['Height Sensor', 'Peak Force Error', 'DMTModulus', 'LogDMTModulus', "
+            "'Adhesion', 'Deformation', 'Dissipation', 'Height']",
             id="'.spm' channel not found.",
         ),
         pytest.param(
@@ -121,8 +124,7 @@ RESOURCES = BASE_DIR / "tests" / "resources"
             "File type '.xxx' is not currently handled by AFMReader.",
             id="'.xxx' unsupported filetype.",
         ),
-    ]
-
+    ],
 )
 def test_load(caplog: pytest.LogCaptureFixture, filepath: Path, channel: str, error: bool, message: str):
     """Test loading of all (asd, gwy, ibw, jpk, spm, stp, top, topostats) filetypes."""
@@ -137,10 +139,11 @@ def test_load(caplog: pytest.LogCaptureFixture, filepath: Path, channel: str, er
     else:
         # check when channel wrong
         assert isinstance(image, ValueError)
-        assert px2nm == None
+        assert px2nm is None
 
     # check output logs
     assert message in caplog.text
+
 
 @pytest.mark.parametrize(
     ("filepath"),
@@ -149,12 +152,12 @@ def test_load(caplog: pytest.LogCaptureFixture, filepath: Path, channel: str, er
             RESOURCES / "not_a_real_file.spm",
             id="File not found error raised.",
         ),
-    ]
+    ],
 )
 def test_load_filenotfounderror(filepath: Path):
     """Test that a file not found error is raise when filepath is wrong."""
     loader = general_loader.LoadFile(filepath, "channel")
 
-    with pytest.raises(FileNotFoundError) as execinfo:
-        image, px2nm = loader.load()
+    with pytest.raises(FileNotFoundError) as execinfo:  # noqa: PT012
+        _, _ = loader.load()
         assert "[not_a_real_file] FileNotFoundError" in execinfo.value

--- a/tests/test_general_loader.py
+++ b/tests/test_general_loader.py
@@ -154,7 +154,7 @@ def test_load(caplog: pytest.LogCaptureFixture, filepath: Path, channel: str, er
         ),
     ],
 )
-def test_load_filenotfounderror(filepath: Path):
+def test_load_filenotfounderror(filepath: Path) -> None:
     """Test that a file not found error is raise when filepath is wrong."""
     loader = general_loader.LoadFile(filepath, "channel")
 


### PR DESCRIPTION
This PR adds a general file loader into ~TopoStats~ AFMReader which handles any filepath and uses the file extention to ship it to the correct reader.

This does include a few funky additions changes:
- The general loader takes a filepath and channel string, and returns a tuple of `(image, px2nm)`.
- As this is made for the Napari plugin we are developing, it needs to "pass along" the error messages to Napari, thus the channel errors are poorly handled by being returned as a tuple of `(ValueError(<message>), None)`.
- For `.topostats` files, it uses the channel input to identify any image keys ("image" and "image_original" from the file). These are also returned for the error message.
- Functions, linting and tests are all there :)