### PR TITLE
packaging: Set pySPM min version to 0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "igor2",
   "loguru",
   "matplotlib",
-  "pySPM",
+  "pySPM~=0.6.2",
   "tifffile",
   "ruamel.yaml",
 ]


### PR DESCRIPTION
I found that for some reason an old version of `pySPM-0.2.23` was pulled in which caused errors as it used deprecated
SciPy libraries (see [closed issue](https://github.com/scholi/pySPM/issues/53)). Its not clear from the
[log](https://productionresultssa1.blob.core.windows.net/actions-results/fa03bab8-0e33-47bc-a2e8-78ec876aa492/workflow-job-run-ea76b43c-ee68-5caa-254f-051e5a73daf3/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-05-15T16%3A10%3A40Z&sig=mocjmoixOhWCRWmd3Vjxtws1iftIh6IBXpAd8s14VmQ%3D&ske=2025-05-16T00%3A42%3A37Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-05-15T12%3A42%3A37Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-05-15T16%3A00%3A35Z&sv=2025-05-05)
why this old version was selected either.

Have therefore pinned the version to `pySPM~=0.6.2` in the hope that forces it to be installed.