### PR TITLE
setup: Use AFM-SPM/pySPM fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "igor2",
   "loguru",
   "matplotlib",
-  "pySPM~=0.6.2",
+  "pySPM @ git+https://github.com/AFM-SPM/pySPM@master",
   "tifffile",
   "ruamel.yaml",
 ]


### PR DESCRIPTION
Stupidly forgot its the [AFM-SPM/pySPM fork](https://github.com/AFM-SPM/pySPM/) where I've bumped the Numpy version to be `^2.0.0` and not simply pinning pySPM~=0.6.2 that is required.  Rushing and being distracted not helpful!