### PR TITLE
chore: Revert pySPM to install from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "igor2",
   "loguru",
   "matplotlib",
-  "pySPM @ git+https://github.com/AFM-SPM/pySPM@master",
+  "pySPM",
   "tifffile",
   "ruamel.yaml",
 ]


### PR DESCRIPTION
[pySPM-0.6.3](https://pypi.org/project/pyspm/0.6.3/) has been released to PyPI and incorporates support for Numpy
2.0 (which was the reason for switching to the AFM-SPM/pySPM fork).

Reverting back which means we will be able to make a new release of AFMReader so that @MaxGamill-Sheffield can update
the `napari-afmreader` package to rely on the PyPI version of AFMReader.